### PR TITLE
feat: header blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pact Cypress
+# Pact Cypress Adaptor
 Generate pact contracts from cypress test.
 
 ## Installation
@@ -23,6 +23,19 @@ Finally, update cypress/support/index.js file to include cypress-pact commands v
 import 'package-name'
 ```
 
+## Configuration
+By default, this plugin omits most cypress auto-generated HTTP headers. 
+To exclude more customised headers in your pact, add allowed headers as a list of string in `cypress.json` under key `env.headersBlocklist`. Eg. in your `cypress.json`
+```js
+{
+    ...otherCypressConfig,
+    "env": {
+        'headersBlocklist': ['ignore-me-globally']
+    }
+}
+```
+
+Note: Header blocklist can be set up at test level. Check command (cy.setupPactHeaderBlocklist)[/#cy.setupPactHeaderBlocklist([headers])]
 
 ## Commands 
 ### cy.setupPact(consumerName:string, providerName: string)
@@ -53,6 +66,22 @@ after(() => {
 
 ```
 
+### cy.setupPactHeaderBlocklist([headers])
+Add a list of headers that will be excluded in a pact at test case level
+
+```js
+before(() => {
+    cy.setupPact('ui-consumer', 'api-provider')
+    cy.intercept('GET', '/users', headers: {'ignore-me': 'ignore me please'}).as('getAllUsers')
+    cy.setupPactHeaderBlocklist(['ignore-me'])
+})
+
+//... cypress test
+
+after(() => {
+    cy.usePactWait(['getAllUsers'])
+})
+```
 
 ### cy.usePactRequest(option, alias) and cy.usePactGet([alias] | alias)
 Use `cy.usePactRequest` to initiate network calls and use `cy.usePactGet` to record network request and response to a pact file.

--- a/README.md
+++ b/README.md
@@ -25,17 +25,31 @@ import 'package-name'
 
 ## Configuration
 By default, this plugin omits most cypress auto-generated HTTP headers. 
+### Add more headers to blocklist
 To exclude other headers in your pact, add them as a list of strings in `cypress.json` under key `env.headersBlocklist`. Eg. in your `cypress.json`
 ```js
 {
     ...otherCypressConfig,
     "env": {
-        'headersBlocklist': ['ignore-me-globally']
+        "headersBlocklist": ["ignore-me-globally"]
     }
 }
 ```
 
-Note: Header blocklist can be set up at test level. Check command (cy.setupPactHeaderBlocklist)[/#cy.setupPactHeaderBlocklist([headers])]
+Note: Header blocklist can be set up at test level. Check command [cy.setupPactHeaderBlocklist](/#cy.setupPactHeaderBlocklist([headers]))
+
+### Ignore cypress auto-generated header blocklist
+To stop cypress auto-generated HTTP headers being omitted by the plugin,  set `env.ignoreDefaultBlocklist` in your `cypress.json`. Eg. in your `cypress.json`
+```js
+{
+    ...otherCypressConfig,
+    "env": {
+        "headersBlocklist": ["ignore-me-globally"],
+        "ignoreDefaultBlocklist": true
+
+    }
+}
+```
 
 ## Commands 
 ### cy.setupPact(consumerName:string, providerName: string)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import 'package-name'
 
 ## Configuration
 By default, this plugin omits most cypress auto-generated HTTP headers. 
-To exclude more customised headers in your pact, add allowed headers as a list of string in `cypress.json` under key `env.headersBlocklist`. Eg. in your `cypress.json`
+To exclude other headers in your pact, add them as a list of strings in `cypress.json` under key `env.headersBlocklist`. Eg. in your `cypress.json`
 ```js
 {
     ...otherCypressConfig,

--- a/example/todo-example/cypress.json
+++ b/example/todo-example/cypress.json
@@ -1,6 +1,6 @@
 {
     "video": false,
     "env": {
-        "headersBlocklist": ["ignore-me-global"]
+        "headersBlocklist": ["ignore-me-globally"]
     }
 }

--- a/example/todo-example/cypress.json
+++ b/example/todo-example/cypress.json
@@ -1,3 +1,6 @@
 {
-    "video": false
+    "video": false,
+    "env": {
+        "headersBlocklist": ["ignore-me-global"]
+    }
 }

--- a/example/todo-example/cypress.json
+++ b/example/todo-example/cypress.json
@@ -1,6 +1,7 @@
 {
     "video": false,
     "env": {
-        "headersBlocklist": ["ignore-me-globally"]
+        "headersBlocklist": ["ignore-me-globally"],
+        "ignoreDefaultBlocklist": false
     }
 }

--- a/example/todo-example/cypress/integration/todo.spec.js
+++ b/example/todo-example/cypress/integration/todo.spec.js
@@ -10,7 +10,7 @@ describe('example to-do app', () => {
         headers: {
           'x-pactflow': 'blah',
           'ignore-me': 'ignore',
-          'ignore-me-global': 'ignore'
+          'ignore-me-globally': 'ignore'
         }
       },
       {

--- a/example/todo-example/cypress/integration/todo.spec.js
+++ b/example/todo-example/cypress/integration/todo.spec.js
@@ -23,7 +23,9 @@ describe('example to-do app', () => {
     cy.visit('http://localhost:3000/')
   })
 
-  it('shows todo', () => {})
+  it('shows todo', () => {
+    cy.contains('clean desk')
+  })
 
   after(() => {
     cy.usePactWait('getTodos').its('response.statusCode').should('eq', 200)

--- a/example/todo-example/cypress/integration/todo.spec.js
+++ b/example/todo-example/cypress/integration/todo.spec.js
@@ -6,7 +6,12 @@ describe('example to-do app', () => {
     cy.intercept(
       {
         method: 'GET',
-        url: '**/api/todo'
+        url: '**/api/todo',
+        headers: {
+          'x-pactflow': 'blah',
+          'ignore-me': 'ignore',
+          'ignore-me-global': 'ignore'
+        }
       },
       {
         statusCode: 200,
@@ -14,6 +19,7 @@ describe('example to-do app', () => {
         headers: { 'access-control-allow-origin': '*' }
       }
     ).as('getTodos')
+    cy.setupPactHeaderBlocklist(['ignore-me'])
     cy.visit('http://localhost:3000/')
   })
 

--- a/example/todo-example/cypress/integration/todoGet.spec.js
+++ b/example/todo-example/cypress/integration/todoGet.spec.js
@@ -6,7 +6,10 @@ describe('example to-do app', () => {
     cy.usePactRequest(
       {
         method: 'GET',
-        url: 'https://jsonplaceholder.typicode.com/todos'
+        url: 'https://jsonplaceholder.typicode.com/todos',
+        headers: {
+          'ignore-me-global': 'me'
+        }
       },
       'getTodosGet'
     )

--- a/example/todo-example/cypress/integration/todoGet.spec.js
+++ b/example/todo-example/cypress/integration/todoGet.spec.js
@@ -16,7 +16,6 @@ describe('example to-do app', () => {
       'getTodosGet'
     )
     cy.setupPactHeaderBlocklist(['ignore-me'])
-    cy.visit('http://localhost:3000/')
   })
 
   it('shows todo', () => {

--- a/example/todo-example/cypress/integration/todoGet.spec.js
+++ b/example/todo-example/cypress/integration/todoGet.spec.js
@@ -8,11 +8,14 @@ describe('example to-do app', () => {
         method: 'GET',
         url: 'https://jsonplaceholder.typicode.com/todos',
         headers: {
-          'ignore-me-global': 'me'
+          'x-pactflow': 'blah',
+          'ignore-me': 'ignore',
+          'ignore-me-globally': 'ignore'
         }
       },
       'getTodosGet'
     )
+    cy.setupPactHeaderBlocklist(['ignore-me'])
     cy.visit('http://localhost:3000/')
   })
 

--- a/example/todo-example/src/App.js
+++ b/example/todo-example/src/App.js
@@ -8,7 +8,7 @@ function App() {
         headers: {
           'x-pactflow': 'blah',
           'ignore-me': 'ignore',
-          'ignore-me-global': 'ignore'
+          'ignore-me-globally': 'ignore'
         }
       })
       response = await response.json()
@@ -17,7 +17,7 @@ function App() {
     fetchTodos()
   }, [])
   return (
-    <div className="App"> {console.log(todos)}
+    <div className="App">
       {todos.length === 1 ? (
         <p>No todos is found</p>
       ) : (

--- a/example/todo-example/src/App.js
+++ b/example/todo-example/src/App.js
@@ -18,7 +18,7 @@ function App() {
   }, [])
   return (
     <div className="App">
-      {todos.length === 1 ? (
+      {todos.length === 0 ? (
         <p>No todos is found</p>
       ) : (
         <ul>

--- a/example/todo-example/src/App.js
+++ b/example/todo-example/src/App.js
@@ -4,7 +4,13 @@ function App() {
   const [todos, setTodos] = useState([])
   useEffect(() => {
     async function fetchTodos() {
-      let response = await fetch('/api/todo')
+      let response = await fetch('/api/todo', {
+        headers: {
+          'x-pactflow': 'blah',
+          'ignore-me': 'ignore',
+          'ignore-me-global': 'ignore'
+        }
+      })
       response = await response.json()
       setTodos(response)
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,19 @@
+export const AUTOGEN_HEADER_BLOCKLIST = [
+  'access-control-expose-headers', 
+  'access-control-allow-credentials', 
+  'host',
+  'proxy-connection',
+  'sec-ch-ua',
+  'sec-ch-ua-mobile',
+  'user-agent',
+  'sec-ch-ua-platform',
+  'origin',
+  'sec-fetch-site',
+  'sec-fetch-mode',
+  'sec-fetch-dest',
+  'referer',
+  'accept-encoding',
+  'accept-language',
+  'date',
+  'x-powered-by'
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,13 +36,13 @@ const usePactWait = (alias: AliasType) => {
   if (formattedAlias.length > 1) {
     cy.wait([...formattedAlias]).spread((...intercepts) => {
       intercepts.forEach((intercept, index) => {
-        writePact(intercept, `${testCaseTitle}-${formattedAlias[index]}`, pactConfig, headersBlocklist)
+        writePact({intercept, testCaseTitle: `${testCaseTitle}-${formattedAlias[index]}`, pactConfig, blocklist: headersBlocklist})
       })
     })
   } else {
     cy.wait(formattedAlias).then((intercept) => {
       const flattenIntercept = Array.isArray(intercept) ? intercept[0] : intercept
-      writePact(flattenIntercept, `${testCaseTitle}`, pactConfig, headersBlocklist)
+      writePact({intercept: flattenIntercept, testCaseTitle: `${testCaseTitle}`, pactConfig, blocklist: headersBlocklist})
     })
   }
 }
@@ -68,7 +68,7 @@ const usePactGet = (alias: string) => {
           statusText: response.statusText
         }
       } as XHRRequestAndResponse
-      writePact(fullRequestAndResponse, `${testCaseTitle}-${alias}`, pactConfig, headersBlocklist)
+      writePact({intercept: fullRequestAndResponse, testCaseTitle: `${testCaseTitle}-${alias}`, pactConfig, blocklist: headersBlocklist})
     })
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,6 @@ const usePactGet = (alias: string) => {
   const testCaseTitle = Cypress.currentTest.title
   formattedAlias.forEach((alias) => {
     cy.get(alias).then((response: any) => {
-      console.log(response)
       const fullRequestAndResponse = {
         request: {
           method: requestDataMap[alias].method,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ declare global {
       usePactWait: (alias: AliasType) => Chainable
       usePactRequest: (option: AnyObject, alias: string) => Chainable
       usePactGet: (alias: string, pactConfig: PactConfigType) => Chainable
-      setupPact:(consumerName: string, providerName: string) => Chainable<null>
+      setupPact: (consumerName: string, providerName: string) => Chainable<null>
+      setupPactHeaderBlocklist: (headers: string[]) => Chainable<null>
     }
   }
 }
@@ -19,8 +20,13 @@ const pactConfig: PactConfigType = {
 }
 
 const setupPact = (consumerName: string, providerName: string) => {
-  pactConfig['consumerName'] =  consumerName
-  pactConfig['providerName'] =  providerName
+  pactConfig['consumerName'] = consumerName
+  pactConfig['providerName'] = providerName
+}
+
+let headersBlocklist: string[] = Cypress.env('headersBlocklist') || []
+const setupPactHeaderBlocklist = (headers: string[]) => {
+  headersBlocklist = [...headers, ...headersBlocklist]
 }
 
 const usePactWait = (alias: AliasType) => {
@@ -30,13 +36,13 @@ const usePactWait = (alias: AliasType) => {
   if (formattedAlias.length > 1) {
     cy.wait([...formattedAlias]).spread((...intercepts) => {
       intercepts.forEach((intercept, index) => {
-        writePact(intercept, `${testCaseTitle}-${formattedAlias[index]}`, pactConfig)
+        writePact(intercept, `${testCaseTitle}-${formattedAlias[index]}`, pactConfig, headersBlocklist)
       })
     })
   } else {
     cy.wait(formattedAlias).then((intercept) => {
       const flattenIntercept = Array.isArray(intercept) ? intercept[0] : intercept
-      writePact(flattenIntercept, `${testCaseTitle}`, pactConfig)
+      writePact(flattenIntercept, `${testCaseTitle}`, pactConfig, headersBlocklist)
     })
   }
 }
@@ -48,7 +54,7 @@ const usePactGet = (alias: string) => {
   const testCaseTitle = Cypress.currentTest.title
   formattedAlias.forEach((alias) => {
     cy.get(alias).then((response: any) => {
-        console.log(response)
+      console.log(response)
       const fullRequestAndResponse = {
         request: {
           method: requestDataMap[alias].method,
@@ -63,7 +69,7 @@ const usePactGet = (alias: string) => {
           statusText: response.statusText
         }
       } as XHRRequestAndResponse
-      writePact(fullRequestAndResponse, `${testCaseTitle}-${alias}`, pactConfig)
+      writePact(fullRequestAndResponse, `${testCaseTitle}-${alias}`, pactConfig, headersBlocklist)
     })
   })
 }
@@ -79,3 +85,4 @@ Cypress.Commands.add('usePactWait', usePactWait)
 Cypress.Commands.add('usePactRequest', usePactRequest)
 Cypress.Commands.add('usePactGet', usePactGet)
 Cypress.Commands.add('setupPact', setupPact)
+Cypress.Commands.add('setupPactHeaderBlocklist', setupPactHeaderBlocklist)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { AUTOGEN_HEADER_BLOCKLIST } from './constants'
 import { AliasType, AnyObject, PactConfigType, XHRRequestAndResponse, RequestOptionType } from 'types'
 import { formatAlias, writePact } from './utils'
 
@@ -25,8 +26,11 @@ const setupPact = (consumerName: string, providerName: string) => {
 }
 
 let headersBlocklist: string[] = Cypress.env('headersBlocklist') || []
+const ignoreDefaultBlocklist = Cypress.env('ignoreDefaultBlocklist') || false
 const setupPactHeaderBlocklist = (headers: string[]) => {
-  headersBlocklist = [...headers, ...headersBlocklist]
+  headersBlocklist = ignoreDefaultBlocklist
+    ? [...headers, ...headersBlocklist]
+    : [...headers, ...headersBlocklist, ...AUTOGEN_HEADER_BLOCKLIST]
 }
 
 const usePactWait = (alias: AliasType) => {
@@ -36,13 +40,23 @@ const usePactWait = (alias: AliasType) => {
   if (formattedAlias.length > 1) {
     cy.wait([...formattedAlias]).spread((...intercepts) => {
       intercepts.forEach((intercept, index) => {
-        writePact({intercept, testCaseTitle: `${testCaseTitle}-${formattedAlias[index]}`, pactConfig, blocklist: headersBlocklist})
+        writePact({
+          intercept,
+          testCaseTitle: `${testCaseTitle}-${formattedAlias[index]}`,
+          pactConfig,
+          blocklist: headersBlocklist
+        })
       })
     })
   } else {
     cy.wait(formattedAlias).then((intercept) => {
       const flattenIntercept = Array.isArray(intercept) ? intercept[0] : intercept
-      writePact({intercept: flattenIntercept, testCaseTitle: `${testCaseTitle}`, pactConfig, blocklist: headersBlocklist})
+      writePact({
+        intercept: flattenIntercept,
+        testCaseTitle: `${testCaseTitle}`,
+        pactConfig,
+        blocklist: headersBlocklist
+      })
     })
   }
 }
@@ -68,7 +82,12 @@ const usePactGet = (alias: string) => {
           statusText: response.statusText
         }
       } as XHRRequestAndResponse
-      writePact({intercept: fullRequestAndResponse, testCaseTitle: `${testCaseTitle}-${alias}`, pactConfig, blocklist: headersBlocklist})
+      writePact({
+        intercept: fullRequestAndResponse,
+        testCaseTitle: `${testCaseTitle}-${alias}`,
+        pactConfig,
+        blocklist: headersBlocklist
+      })
     })
   })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Interception } from 'cypress/types/net-stubbing'
+
 export type AliasType = string | string[]
 
 export type AnyObject = {
@@ -9,8 +11,10 @@ export type PactConfigType = {
   providerName: string
 }
 
+export type HeaderType = Record<string, string | string[]> | undefined
+
 type BaseXHR = {
-  headers: Record<string, string | string[]> | undefined
+  headers: HeaderType
   body: any | undefined
 }
 export type Interaction = {
@@ -38,7 +42,19 @@ export type XHRRequestAndResponse = {
   } & BaseXHR
 }
 
-type Encodings = 'ascii' | 'base64' | 'binary' | 'hex' | 'latin1' | 'utf8' | 'utf-8' | 'ucs2' | 'ucs-2' | 'utf16le' | 'utf-16le' | null
+type Encodings =
+  | 'ascii'
+  | 'base64'
+  | 'binary'
+  | 'hex'
+  | 'latin1'
+  | 'utf8'
+  | 'utf-8'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'utf16le'
+  | 'utf-16le'
+  | null
 
 export type RequestOptionType = {
   auth: object
@@ -51,4 +67,12 @@ export type RequestOptionType = {
   method: string
   qs: object
   url: string
+}
+
+export type PactFileType = {
+  intercept: Interception | XHRRequestAndResponse
+  testCaseTitle: string
+  pactConfig: PactConfigType
+  blocklist?: string[],
+  content?: any 
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { Interception } from 'cypress/types/net-stubbing'
-import { AUTOGEN_HEADER_BLOCKLIST } from './constants'
 import { uniqBy, reverse, omit } from 'lodash'
 import { AliasType, Interaction, PactConfigType, XHRRequestAndResponse, PactFileType, HeaderType } from 'types'
 
@@ -33,7 +32,7 @@ export const writePact = ({ intercept, testCaseTitle, pactConfig, blocklist }: P
 }
 
 export const omitHeaders = (headers: HeaderType, blocklist: string[]) => {
-  return omit(headers, [...blocklist, ...AUTOGEN_HEADER_BLOCKLIST])
+  return omit(headers, [...blocklist])
 }
 
 const constructInteraction = (

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,7 @@
-import { formatAlias, constructPactFile, readFileAsync } from '../src/utils'
+import { formatAlias, constructPactFile, readFileAsync, omitHeaders } from '../src/utils'
 import { expect } from '@jest/globals'
 import { XHRRequestAndResponse } from '../src/types'
+import * as Cypress from 'cypress'
 
 import { promises, Stats } from 'fs'
 
@@ -76,6 +77,7 @@ describe('constructPactFile', () => {
         consumerName: 'ui-consumer',
         providerName: 'todo-api'
       },
+      [],
       existingContent
     )
     expect(result.interactions.length).toBe(2)
@@ -104,7 +106,7 @@ describe('constructPactFile', () => {
   })
 })
 
-describe('readFile',  () => {
+describe('readFile', () => {
   it('should return null when no file is found', async () => {
     const mock = jest.spyOn(promises, 'stat')
     mock.mockReturnValue(
@@ -132,5 +134,19 @@ describe('readFile',  () => {
     )
     const fileContent = await readFileAsync(promises, 'hello')
     expect(fileContent).toBe('hello')
+  })
+})
+
+describe('omitHeaders', () => {
+  it('should omit auto-generated headers and header from customised blocklist', () => {
+    const result = omitHeaders(
+      {
+        referer: 'me',
+        'x-pactflow': 'lol',
+        'ignore-me': 'ignore'
+      },
+      ['ignore-me']
+    )
+    expect(result).toStrictEqual({ 'x-pactflow': 'lol' })
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,7 +1,6 @@
 import { formatAlias, constructPactFile, readFileAsync, omitHeaders } from '../src/utils'
 import { expect } from '@jest/globals'
 import { XHRRequestAndResponse } from '../src/types'
-import * as Cypress from 'cypress'
 
 import { promises, Stats } from 'fs'
 
@@ -70,16 +69,16 @@ describe('constructPactFile', () => {
         statusText: 'Created'
       }
     } as XHRRequestAndResponse
-    const result = constructPactFile(
-      newIntercept,
-      'create todo',
-      {
+    const result = constructPactFile({
+      intercept: newIntercept,
+      testCaseTitle: 'create todo',
+      pactConfig: {
         consumerName: 'ui-consumer',
         providerName: 'todo-api'
       },
-      [],
-      existingContent
-    )
+      blocklist: [],
+      content: existingContent
+    })
     expect(result.interactions.length).toBe(2)
     expect(result.interactions[1].description).toBe('create todo')
   })
@@ -96,9 +95,13 @@ describe('constructPactFile', () => {
         statusText: 'Created'
       }
     } as XHRRequestAndResponse
-    const result = constructPactFile(newIntercept, 'create todo', {
-      consumerName: 'ui-consumer',
-      providerName: 'todo-api'
+    const result = constructPactFile({
+      intercept: newIntercept,
+      testCaseTitle: 'create todo',
+      pactConfig: {
+        consumerName: 'ui-consumer',
+        providerName: 'todo-api'
+      }
     })
     expect(result.consumer.name).toBe('ui-consumer')
     expect(result.provider.name).toBe('todo-api')

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -148,7 +148,7 @@ describe('omitHeaders', () => {
         'x-pactflow': 'lol',
         'ignore-me': 'ignore'
       },
-      ['ignore-me']
+      ['ignore-me', 'referer']
     )
     expect(result).toStrictEqual({ 'x-pactflow': 'lol' })
   })


### PR DESCRIPTION
- rule out auto-generated headers
- support customisable header blocklist:
  - add `cy.setupPactHeaderBlocklist` command to support test level setup
  - support cypress environment variable `headerBlocklist` to exclude a list of headers
  - add cypress environment variable `ignoreDefaultBlocklist` to stop headers from `AUTOGEN_HEADER_BLOCKLIST` being omitted